### PR TITLE
Move default repo to mfl-devel

### DIFF
--- a/copr.mk
+++ b/copr.mk
@@ -12,7 +12,7 @@ endif
 
 ifneq ($(filter iml_%,$(MAKECMDGOALS)),)
   COPR_CONFIG := --config include/copr-mfl
-  OWNER_PROJECT = managerforlustre/manager-for-lustre
+  OWNER_PROJECT = managerforlustre/manager-for-lustre-devel
 else
   # local settings
   -include copr-local.mk

--- a/travis/mock_build_test.sh
+++ b/travis/mock_build_test.sh
@@ -18,9 +18,9 @@ fi
 ed <<"EOF" /etc/mock/default.cfg
 $i
 
-[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre_epel-7-x86_64_]
-name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/
-baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/
+[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre-devel_epel-7-x86_64_]
+name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
 enabled=1
 .
 wq


### PR DESCRIPTION
We should be publishing to mfl-devel by default.
The production repo should be a fork (clone?) of devel once it's ready.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>